### PR TITLE
Add missing mkl module in LLNL-LC.mod for DLARS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ hosttype=""
 
 if [[ $lochost == *"arc-ts.umich.edu"* ]]; then
     hosttype=UM-ARC
-elif [[ $lochost == *"arc-ts.umich.edu"* ]]; then
+elif [[ $lochost == *"quartz"* ]]; then
     hosttype=LLNL-LC
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -41,6 +41,9 @@ if [[ $lochost == *"arc-ts.umich.edu"* ]]; then
     hosttype=UM-ARC
 elif [[ $lochost == *"quartz"* ]]; then
     hosttype=LLNL-LC
+else
+    echo "WARNING: Host type ($hosttype) unknown"
+    echo "Be sure to load modules/conifugre compilers by hand."
 fi
 
 # Load module files and configure compilers


### PR DESCRIPTION
This fix is required to enable automated compilation of DLARS via export hosttype=LLNL-LC; ./install.sh. Users previously had to pre-load this module by hand.